### PR TITLE
Update lr version

### DIFF
--- a/lr-bench/Cargo.toml
+++ b/lr-bench/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 workspace = ".."
 
 [dev-dependencies]
-criterion = "0.4.0"
+criterion = "0.4"
 
 [[bench]]
 name = "lr_calculator_expr"

--- a/lr-bench/benches/lr_calculator_expr.rs
+++ b/lr-bench/benches/lr_calculator_expr.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use lr_core::{TerminalOrNonTerminal, TerminalRepresentable};
+use lr_core::{NonTerminalRepresentable, TerminalOrNonTerminal, TerminalRepresentable};
 pub use lr_derive::Lr1;
 pub use relex_derive::{Relex, VariantKind};
 
@@ -200,6 +200,10 @@ pub enum NonTerminal {
     Multiplicative(Box<ExprInner>),
     #[production(r"Terminal::Int", reduce_primary)]
     Primary(Terminal),
+}
+
+impl NonTerminalRepresentable for NonTerminal {
+    type Terminal = Terminal;
 }
 
 fn parse_basic_expression(c: &mut Criterion) {


### PR DESCRIPTION
https://github.com/ncatelli/lr/pull/26 introduced changes to the API, requiring an additional trait implementation for nonterminal symbols. This PR adds this.